### PR TITLE
rename eshelby to dislocation

### DIFF
--- a/elaston/dislocation.py
+++ b/elaston/dislocation.py
@@ -19,7 +19,7 @@ __status__ = "development"
 __date__ = "Aug 21, 2021"
 
 
-class Eshelby:
+class Dislocation:
     """
     Anisotropic elasticity theory for dislocations described by
     [Eshelby](https://doi.org/10.1016/0001-6160(53)90099-6).
@@ -145,7 +145,7 @@ def get_dislocation_displacement(
     Returns:
         ((n, 3)-array): Displacement field (z-axis coincides with the dislocation line)
     """
-    return Eshelby(elastic_tensor, burgers_vector).get_displacement(positions)
+    return Dislocation(elastic_tensor, burgers_vector).get_displacement(positions)
 
 
 @units(outputs=lambda burgers_vector, positions: burgers_vector.u / positions.u)
@@ -167,7 +167,7 @@ def get_dislocation_strain(
     Returns:
         ((n, 3, 3)-array): Strain field (z-axis coincides with the dislocation line)
     """
-    return Eshelby(elastic_tensor, burgers_vector).get_strain(positions)
+    return Dislocation(elastic_tensor, burgers_vector).get_strain(positions)
 
 
 @units(

--- a/elaston/linear_elasticity.py
+++ b/elaston/linear_elasticity.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 from elaston.green import Anisotropic, Isotropic, Green
-from elaston import eshelby
+from elaston import dislocation
 from elaston import tools
 from elaston import elastic_constants
 
@@ -449,7 +449,7 @@ class LinearElasticity:
             ((n, 3)-array): Displacement field (z-axis coincides with the
                 dislocation line)
         """
-        return eshelby.get_dislocation_displacement(
+        return dislocation.get_dislocation_displacement(
             self.get_elastic_tensor(), positions, burgers_vector
         )
 
@@ -470,7 +470,7 @@ class LinearElasticity:
         Returns:
             ((n, 3, 3)-array): Strain field (z-axis coincides with the dislocation line)
         """
-        return eshelby.get_dislocation_strain(
+        return dislocation.get_dislocation_strain(
             self.get_elastic_tensor(), positions, burgers_vector
         )
 
@@ -491,7 +491,7 @@ class LinearElasticity:
         Returns:
             ((n, 3, 3)-array): Stress field (z-axis coincides with the dislocation line)
         """
-        return eshelby.get_dislocation_stress(
+        return dislocation.get_dislocation_stress(
             self.get_elastic_tensor(), positions, burgers_vector
         )
 
@@ -512,7 +512,7 @@ class LinearElasticity:
         Returns:
             ((n,)-array): Energy density field
         """
-        return eshelby.get_dislocation_energy_density(
+        return dislocation.get_dislocation_energy_density(
             self.get_elastic_tensor(), positions, burgers_vector
         )
 
@@ -556,7 +556,7 @@ class LinearElasticity:
         based on the real dislocation density, the choice of :math:`r_min`
         should be done carefully.
         """
-        return eshelby.get_dislocation_energy(
+        return dislocation.get_dislocation_energy(
             self.get_elastic_tensor(), burgers_vector, r_min, r_max, mesh
         )
 
@@ -591,7 +591,7 @@ class LinearElasticity:
 
         Source: https://en.wikipedia.org/wiki/Stacking-fault_energy
         """
-        return eshelby.get_dislocation_force(stress, glide_plane, burgers_vector)
+        return dislocation.get_dislocation_force(stress, glide_plane, burgers_vector)
 
     def get_voigt_average(self):
         """

--- a/tests/unit/test_dislocation.py
+++ b/tests/unit/test_dislocation.py
@@ -1,6 +1,6 @@
 import numpy as np
 import unittest
-from elaston.eshelby import Eshelby
+from elaston.dislocation import Dislocation
 from elaston import tools
 
 
@@ -12,10 +12,10 @@ def create_random_HL(b=None):
     C = tools.C_from_voigt(C)
     if b is None:
         b = np.random.random(3)
-    return Eshelby(C, b)
+    return Dislocation(C, b)
 
 
-class TestEschelby(unittest.TestCase):
+class TestDislocation(unittest.TestCase):
     def test_p(self):
         hl = create_random_HL()
         self.assertLess(


### PR DESCRIPTION
I renamed `Eshelby` to `Dislocation` to make it clearer what it does, as `Eshelby` can mean really a lot of things.