### PR TITLE
Rename green

### DIFF
--- a/elaston/elastic_constants.py
+++ b/elaston/elastic_constants.py
@@ -183,7 +183,7 @@ def is_cubic(C):
     Check if the material is cubic
 
     Args:
-        C (np.ndarray): Elastic constants in Voigt notation
+        C (np.ndarray): Elastic constants in Voigt notation or full tensor
 
     Returns:
         bool: True if the material is cubic
@@ -203,7 +203,7 @@ def is_isotropic(C):
     Check if the material is isotropic
 
     Args:
-        C (np.ndarray): Elastic constants in Voigt notation
+        C (np.ndarray): Elastic constants in Voigt notation or full tensor
 
     Returns:
         bool: True if the material is isotropic

--- a/elaston/elastic_constants.py
+++ b/elaston/elastic_constants.py
@@ -188,12 +188,29 @@ def is_cubic(C):
     Returns:
         bool: True if the material is cubic
     """
+    if np.shape(C) == (3, 3, 3, 3):
+        C = tools.C_to_voigt(C)
     return all(
         [
             np.isclose(np.ptp(C[ind]), 0)
             for ind in [get_C_11_indices(), get_C_12_indices(), get_C_44_indices()]
         ]
     )
+
+
+def is_isotropic(C):
+    """
+    Check if the material is isotropic
+
+    Args:
+        C (np.ndarray): Elastic constants in Voigt notation
+
+    Returns:
+        bool: True if the material is isotropic
+    """
+    if np.shape(C) == (3, 3, 3, 3):
+        C = tools.C_to_voigt(C)
+    return is_cubic(C) and np.isclose(get_zener_ratio(C), 1)
 
 
 def get_zener_ratio(C):
@@ -225,6 +242,8 @@ def get_unique_elastic_constants(C):
 
 
 def get_elastic_moduli(C):
+    if np.shape(C) == (3, 3, 3, 3):
+        C = tools.C_to_voigt(C)
     C_11 = np.mean(C[get_C_11_indices()])
     C_12 = np.mean(C[get_C_12_indices()])
     C_44 = np.mean(C[get_C_44_indices()])

--- a/elaston/green.py
+++ b/elaston/green.py
@@ -440,3 +440,6 @@ def get_greens_function(
         fourier=fourier,
         check_unique=check_unique,
     )
+
+
+get_greens_function.__doc__ += Green.__doc__

--- a/elaston/inclusion.py
+++ b/elaston/inclusion.py
@@ -1,0 +1,270 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import numpy as np
+from elaston.green import Anisotropic, Isotropic, Green
+from elaston import dislocation
+from elaston import tools
+from elaston import elastic_constants
+
+__author__ = "Sam Waseda"
+__copyright__ = (
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
+    "- Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Sam Waseda"
+__email__ = "waseda@mpie.de"
+__status__ = "development"
+__date__ = "Aug 21, 2021"
+
+
+point_defect_explanation = """
+According to the definition of the Green's function (cf. docstring of `get_greens_function`):
+
+.. math:
+    u_i(r) = \\sum_a G_{ij}(r-a)f_j(a)
+
+where :math:`u_i(r)` is the displacement field of component :math:`i` at position :math:`r` and
+:math:`f_j(a)` is the force component :math:`j` of the atom at position :math:`a`. By taking the
+polynomial development we obtain:
+
+.. math:
+    u_i(r) \\approx G_{ij}(r)\\sum_a f_j(a)-\\frac{\\partial G_{ij}}{\\partial r_k}(r)\\sum_a a_k f_j(a)
+
+The first term disappears because the sum of the forces is zero. From the second term we define
+the dipole tensor :math:`P_{jk} = a_k f_j(a)`. Following the definition above, we can obtain the
+displacement field, strain field, stress field and energy density field if the dipole tensor and
+the elastic tensor are known.
+
+The dipole tensor of a point defect is commonly obtained from the following equation:
+
+.. math:
+    U = \\frac{V}{2} \\varepsilon_{ij}C_{ijkl}\\varepsilon_{kl}-P_{kl}\\varepsilon_{kl}
+
+where :math:`U` is the potential energy, :math:`V` is the volume and :math:`\\varepsilon` is the
+strain field. At equilibrium, the derivative of the potential energy with respect to the strain
+disappears:
+
+.. math:
+    P_{ij} = VC_{ijkl}\\varepsilon_{kl} = V\\sigma_{ij}
+
+With this in mind, we can calculate the dipole tensor of Ni in Al with the following lines:
+
+>>> from pyiron_atomistics import Project
+>>> pr = Project('dipole_tensor')
+>>> job = pr.create.job.Lammps('dipole')
+>>> n_repeat = 3
+>>> job.structure = pr.create.structure.bulk('Al', cubic=True).repeat(n_repeat)
+>>> job.structure[0] = 'Ni'
+>>> job.calc_minimize()
+>>> job.run()
+>>> dipole_tensor = -job.structure.get_volume() * job['output/generic/pressures'][-1]
+
+Instead of working with atomistic calculations, the dipole tensor can be calculated by the
+lambda tensor [1], which is defined as:
+
+.. math:
+    \\lambda_{ij} = \\frac{1]{V} \\frac{\\partial \\varepsilon_{ij}}{\\partial c}
+
+where :math:`c` is the concentration of the defect, :math:`V` is the volume
+and :math:`\\varepsilon` is the strain field. Then the dipole tensor is given by:
+
+.. math:
+    P_{ij} = VC_{ijkl}\\lambda_{kl}
+
+ref:
+
+[1]
+Nowick, Arthur S.
+Anelastic relaxation in crystalline solids.
+Vol. 1. Elsevier, 2012.
+"""
+
+
+def get_greens_function(
+    self,
+    positions: np.ndarray,
+    derivative: int = 0,
+    fourier: bool = False,
+    n_mesh: int = 100,
+    optimize: bool = True,
+    check_unique: bool = False,
+):
+    """
+    Green's function of the equilibrium condition:
+
+    C_ijkl d^2u_k/dx_jdx_l = 0
+
+    Args:
+        positions ((n,3)-array): Positions in real space or reciprocal
+            space (if fourier=True).
+        derivative (int): 0th, 1st or 2nd derivative of the Green's
+            function. Ignored if `fourier=True`.
+        fourier (bool): If `True`,  the Green's function of the reciprocal
+            space is returned.
+        n_mesh (int): Number of mesh points in the radial integration in
+            case if anisotropic Green's function (ignored if isotropic=True
+            or fourier=True)
+        optimize (bool): cf. `optimize` in `numpy.einsum`
+        check_unique (bool): Whether to check the unique positions
+
+    Returns:
+        ((n,3,3)-array): Green's function values for the given positions
+    """
+    if self.is_isotropic():
+        param = self.get_elastic_moduli()
+        C = Isotropic(
+            param["poissons_ratio"], param["shear_modulus"], optimize=optimize
+        )
+    else:
+        C = Anisotropic(self.get_elastic_tensor(), n_mesh=n_mesh, optimize=optimize)
+    return C.get_greens_function(
+        r=positions,
+        derivative=derivative,
+        fourier=fourier,
+        check_unique=check_unique,
+    )
+
+get_greens_function.__doc__ += Green.__doc__
+
+def get_point_defect_displacement(
+    self,
+    positions: np.ndarray,
+    dipole_tensor: np.ndarray,
+    n_mesh: int = 100,
+    optimize: bool = True,
+    check_unique: bool = False,
+):
+    """
+    Displacement field around a point defect
+
+    Args:
+        positions ((n,3)-array): Positions in real space or reciprocal
+            space (if fourier=True).
+        dipole_tensor ((3,3)-array): Dipole tensor
+        n_mesh (int): Number of mesh points in the radial integration in
+            case if anisotropic Green's function (ignored if isotropic=True
+            or fourier=True)
+        optimize (bool): cf. `optimize` in `numpy.einsum`
+        check_unique (bool): Whether to check the unique positions
+
+    Returns:
+        ((n,3)-array): Displacement field
+    """
+    g_tmp = self.get_greens_function(
+        positions,
+        derivative=1,
+        fourier=False,
+        n_mesh=n_mesh,
+        optimize=optimize,
+        check_unique=check_unique,
+    )
+    return -np.einsum("...ijk,...jk->...i", g_tmp, dipole_tensor)
+
+get_point_defect_displacement.__doc__ += point_defect_explanation
+
+def get_point_defect_strain(
+    self,
+    positions: np.ndarray,
+    dipole_tensor: np.ndarray,
+    n_mesh: int = 100,
+    optimize: bool = True,
+    check_unique: bool = False,
+):
+    """
+    Strain field around a point defect using the Green's function method
+
+    Args:
+        positions ((n,3)-array): Positions in real space or reciprocal
+            space (if fourier=True).
+        dipole_tensor ((3,3)-array): Dipole tensor
+        n_mesh (int): Number of mesh points in the radial integration in
+            case if anisotropic Green's function (ignored if isotropic=True
+            or fourier=True)
+        optimize (bool): cf. `optimize` in `numpy.einsum`
+        check_unique (bool): Whether to check the unique positions
+
+    Returns:
+        ((n,3,3)-array): Strain field
+    """
+    g_tmp = self.get_greens_function(
+        positions,
+        derivative=2,
+        fourier=False,
+        n_mesh=n_mesh,
+        optimize=optimize,
+        check_unique=check_unique,
+    )
+    v = -np.einsum("...ijkl,...kl->...ij", g_tmp, dipole_tensor)
+    return 0.5 * (v + np.einsum("...ij->...ji", v))
+
+get_point_defect_strain.__doc__ += point_defect_explanation
+
+def get_point_defect_stress(
+    self,
+    positions: np.ndarray,
+    dipole_tensor: np.ndarray,
+    n_mesh: int = 100,
+    optimize: bool = True,
+):
+    """
+    Stress field around a point defect using the Green's function method
+
+    Args:
+        positions ((n,3)-array): Positions in real space or reciprocal
+            space (if fourier=True).
+        dipole_tensor ((3,3)-array): Dipole tensor
+        n_mesh (int): Number of mesh points in the radial integration in
+            case if anisotropic Green's function (ignored if isotropic=True
+            or fourier=True)
+        optimize (bool): cf. `optimize` in `numpy.einsum`
+
+    Returns:
+        ((n,3,3)-array): Stress field
+    """
+    strain = self.get_point_defect_strain(
+        positions=positions,
+        dipole_tensor=dipole_tensor,
+        n_mesh=n_mesh,
+        optimize=optimize,
+    )
+    return np.einsum("ijkl,...kl->...ij", self.get_elastic_tensor(), strain)
+
+get_point_defect_stress.__doc__ += point_defect_explanation
+
+def get_point_defect_energy_density(
+    self,
+    positions: np.ndarray,
+    dipole_tensor: np.ndarray,
+    n_mesh: int = 100,
+    optimize: bool = True,
+):
+    """
+    Energy density field around a point defect using the Green's function method
+
+    Args:
+        positions ((n,3)-array): Positions in real space or reciprocal
+            space (if fourier=True).
+        dipole_tensor ((3,3)-array): Dipole tensor
+        n_mesh (int): Number of mesh points in the radial integration in
+            case if anisotropic Green's function (ignored if isotropic=True
+            or fourier=True)
+        optimize (bool): cf. `optimize` in `numpy.einsum`
+
+    Returns:
+        ((n,)-array): Energy density field
+    """
+    strain = self.get_point_defect_strain(
+        positions=positions,
+        dipole_tensor=dipole_tensor,
+        n_mesh=n_mesh,
+        optimize=optimize,
+    )
+    return np.einsum(
+        "ijkl,...kl,...ij->...", self.get_elastic_tensor(), strain, strain
+    )
+
+get_point_defect_energy_density.__doc__ += point_defect_explanation
+

--- a/elaston/linear_elasticity.py
+++ b/elaston/linear_elasticity.py
@@ -232,7 +232,9 @@ class LinearElasticity:
         )
 
     def is_isotropic(self):
-        return self.is_cubic() and np.isclose(self.get_zener_ratio(), 1)
+        return elastic_constants.is_isotropic(
+            self.get_elastic_tensor(voigt=True, rotate=False)
+        )
 
     def get_elastic_moduli(self):
         if not self.is_isotropic():

--- a/elaston/linear_elasticity.py
+++ b/elaston/linear_elasticity.py
@@ -3,7 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import numpy as np
-from elaston.green import Anisotropic, Isotropic, Green
+from elaston.green import get_greens_function as get_greens
 from elaston import dislocation
 from elaston import tools
 from elaston import elastic_constants
@@ -19,69 +19,6 @@ __maintainer__ = "Sam Waseda"
 __email__ = "waseda@mpie.de"
 __status__ = "development"
 __date__ = "Aug 21, 2021"
-
-
-point_defect_explanation = """
-According to the definition of the Green's function (cf. docstring of `get_greens_function`):
-
-.. math:
-    u_i(r) = \\sum_a G_{ij}(r-a)f_j(a)
-
-where :math:`u_i(r)` is the displacement field of component :math:`i` at position :math:`r` and
-:math:`f_j(a)` is the force component :math:`j` of the atom at position :math:`a`. By taking the
-polynomial development we obtain:
-
-.. math:
-    u_i(r) \\approx G_{ij}(r)\\sum_a f_j(a)-\\frac{\\partial G_{ij}}{\\partial r_k}(r)\\sum_a a_k f_j(a)
-
-The first term disappears because the sum of the forces is zero. From the second term we define
-the dipole tensor :math:`P_{jk} = a_k f_j(a)`. Following the definition above, we can obtain the
-displacement field, strain field, stress field and energy density field if the dipole tensor and
-the elastic tensor are known.
-
-The dipole tensor of a point defect is commonly obtained from the following equation:
-
-.. math:
-    U = \\frac{V}{2} \\varepsilon_{ij}C_{ijkl}\\varepsilon_{kl}-P_{kl}\\varepsilon_{kl}
-
-where :math:`U` is the potential energy, :math:`V` is the volume and :math:`\\varepsilon` is the
-strain field. At equilibrium, the derivative of the potential energy with respect to the strain
-disappears:
-
-.. math:
-    P_{ij} = VC_{ijkl}\\varepsilon_{kl} = V\\sigma_{ij}
-
-With this in mind, we can calculate the dipole tensor of Ni in Al with the following lines:
-
->>> from pyiron_atomistics import Project
->>> pr = Project('dipole_tensor')
->>> job = pr.create.job.Lammps('dipole')
->>> n_repeat = 3
->>> job.structure = pr.create.structure.bulk('Al', cubic=True).repeat(n_repeat)
->>> job.structure[0] = 'Ni'
->>> job.calc_minimize()
->>> job.run()
->>> dipole_tensor = -job.structure.get_volume() * job['output/generic/pressures'][-1]
-
-Instead of working with atomistic calculations, the dipole tensor can be calculated by the
-lambda tensor [1], which is defined as:
-
-.. math:
-    \\lambda_{ij} = \\frac{1]{V} \\frac{\\partial \\varepsilon_{ij}}{\\partial c}
-
-where :math:`c` is the concentration of the defect, :math:`V` is the volume
-and :math:`\\varepsilon` is the strain field. Then the dipole tensor is given by:
-
-.. math:
-    P_{ij} = VC_{ijkl}\\lambda_{kl}
-
-ref:
-
-[1]
-Nowick, Arthur S.
-Anelastic relaxation in crystalline solids.
-Vol. 1. Elsevier, 2012.
-"""
 
 
 class LinearElasticity:
@@ -278,21 +215,17 @@ class LinearElasticity:
         Returns:
             ((n,3,3)-array): Green's function values for the given positions
         """
-        if self.is_isotropic():
-            param = self.get_elastic_moduli()
-            C = Isotropic(
-                param["poissons_ratio"], param["shear_modulus"], optimize=optimize
-            )
-        else:
-            C = Anisotropic(self.get_elastic_tensor(), n_mesh=n_mesh, optimize=optimize)
-        return C.get_greens_function(
-            r=positions,
+        return get_greens(
+            C=self.get_elastic_tensor(),
+            positions=positions,
             derivative=derivative,
             fourier=fourier,
+            n_mesh=n_mesh,
+            optimize=optimize,
             check_unique=check_unique,
         )
 
-    get_greens_function.__doc__ += Green.__doc__
+    get_greens_function.__doc__ += get_greens.__doc__
 
     def get_point_defect_displacement(
         self,
@@ -318,17 +251,16 @@ class LinearElasticity:
         Returns:
             ((n,3)-array): Displacement field
         """
-        g_tmp = self.get_greens_function(
-            positions,
-            derivative=1,
-            fourier=False,
+        return inclusion.get_point_defect_displacement(
+            C=self.get_elastic_tensor(),
+            positions=positions,
+            dipole_tensor=dipole_tensor,
             n_mesh=n_mesh,
             optimize=optimize,
             check_unique=check_unique,
         )
-        return -np.einsum("...ijk,...jk->...i", g_tmp, dipole_tensor)
 
-    get_point_defect_displacement.__doc__ += point_defect_explanation
+    get_point_defect_displacement.__doc__ += inclusion.point_defect_explanation
 
     def get_point_defect_strain(
         self,
@@ -354,18 +286,16 @@ class LinearElasticity:
         Returns:
             ((n,3,3)-array): Strain field
         """
-        g_tmp = self.get_greens_function(
-            positions,
-            derivative=2,
-            fourier=False,
+        return inclusion.get_point_defect_strain(
+            C=self.get_elastic_tensor(),
+            positions=positions,
+            dipole_tensor=dipole_tensor,
             n_mesh=n_mesh,
             optimize=optimize,
             check_unique=check_unique,
         )
-        v = -np.einsum("...ijkl,...kl->...ij", g_tmp, dipole_tensor)
-        return 0.5 * (v + np.einsum("...ij->...ji", v))
 
-    get_point_defect_strain.__doc__ += point_defect_explanation
+    get_point_defect_strain.__doc__ += inclusion.point_defect_explanation
 
     def get_point_defect_stress(
         self,
@@ -389,15 +319,15 @@ class LinearElasticity:
         Returns:
             ((n,3,3)-array): Stress field
         """
-        strain = self.get_point_defect_strain(
+        return inclusion.get_point_defect_stress(
+            C=self.get_elastic_tensor(),
             positions=positions,
             dipole_tensor=dipole_tensor,
             n_mesh=n_mesh,
             optimize=optimize,
         )
-        return np.einsum("ijkl,...kl->...ij", self.get_elastic_tensor(), strain)
 
-    get_point_defect_stress.__doc__ += point_defect_explanation
+    get_point_defect_stress.__doc__ += inclusion.point_defect_explanation
 
     def get_point_defect_energy_density(
         self,
@@ -421,17 +351,15 @@ class LinearElasticity:
         Returns:
             ((n,)-array): Energy density field
         """
-        strain = self.get_point_defect_strain(
+        return inclusion.get_point_defect_energy_density(
+            C=self.get_elastic_tensor(),
             positions=positions,
             dipole_tensor=dipole_tensor,
             n_mesh=n_mesh,
             optimize=optimize,
         )
-        return np.einsum(
-            "ijkl,...kl,...ij->...", self.get_elastic_tensor(), strain, strain
-        )
 
-    get_point_defect_energy_density.__doc__ += point_defect_explanation
+    get_point_defect_energy_density.__doc__ += inclusion.point_defect_explanation
 
     def get_dislocation_displacement(
         self,

--- a/elaston/linear_elasticity.py
+++ b/elaston/linear_elasticity.py
@@ -7,6 +7,7 @@ from elaston.green import Anisotropic, Isotropic, Green
 from elaston import dislocation
 from elaston import tools
 from elaston import elastic_constants
+from elaston import inclusion
 
 __author__ = "Sam Waseda"
 __copyright__ = (

--- a/elaston/linear_elasticity.py
+++ b/elaston/linear_elasticity.py
@@ -3,7 +3,6 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import numpy as np
-from elaston.green import get_greens_function as get_greens
 from elaston import dislocation
 from elaston import tools
 from elaston import elastic_constants
@@ -184,48 +183,6 @@ class LinearElasticity:
         return elastic_constants.get_elastic_moduli(
             self.get_elastic_tensor(voigt=True, rotate=False)
         )
-
-    def get_greens_function(
-        self,
-        positions: np.ndarray,
-        derivative: int = 0,
-        fourier: bool = False,
-        n_mesh: int = 100,
-        optimize: bool = True,
-        check_unique: bool = False,
-    ):
-        """
-        Green's function of the equilibrium condition:
-
-        C_ijkl d^2u_k/dx_jdx_l = 0
-
-        Args:
-            positions ((n,3)-array): Positions in real space or reciprocal
-                space (if fourier=True).
-            derivative (int): 0th, 1st or 2nd derivative of the Green's
-                function. Ignored if `fourier=True`.
-            fourier (bool): If `True`,  the Green's function of the reciprocal
-                space is returned.
-            n_mesh (int): Number of mesh points in the radial integration in
-                case if anisotropic Green's function (ignored if isotropic=True
-                or fourier=True)
-            optimize (bool): cf. `optimize` in `numpy.einsum`
-            check_unique (bool): Whether to check the unique positions
-
-        Returns:
-            ((n,3,3)-array): Green's function values for the given positions
-        """
-        return get_greens(
-            C=self.get_elastic_tensor(),
-            positions=positions,
-            derivative=derivative,
-            fourier=fourier,
-            n_mesh=n_mesh,
-            optimize=optimize,
-            check_unique=check_unique,
-        )
-
-    get_greens_function.__doc__ += get_greens.__doc__
 
     def get_point_defect_displacement(
         self,

--- a/tests/unit/test_elasticity.py
+++ b/tests/unit/test_elasticity.py
@@ -22,6 +22,17 @@ def create_random_C(isotropic=False):
 
 
 class TestElasticity(unittest.TestCase):
+    def test_cubic(self):
+        medium = LinearElasticity(C_11=211.0, C_12=130.0, C_44=82.0, C_13=140.0)
+        self.assertFalse(medium.is_isotropic())
+        self.assertFalse(medium.is_cubic())
+        medium = LinearElasticity(C_11=211.0, C_12=130.0, C_44=82.0)
+        self.assertFalse(medium.is_isotropic())
+        self.assertTrue(medium.is_cubic())
+        medium = LinearElasticity(C_11=211.0, C_12=130.0)
+        self.assertTrue(medium.is_isotropic())
+        self.assertTrue(medium.is_cubic())
+
     def test_frame(self):
         medium = LinearElasticity(np.random.random((6, 6)))
         self.assertIsNone(medium.orientation)


### PR DESCRIPTION
I separated the inclusion/point defects from the main module, in order to create functions for them, in order to be able to apply units. At the same time, I removed `get_greens_function` from the main module, because it’s not really a physical quantity.