### PR TITLE
Optional units

### DIFF
--- a/elaston/elastic_constants.py
+++ b/elaston/elastic_constants.py
@@ -164,6 +164,7 @@ def get_elastic_tensor_from_moduli(
     )
 
 
+@units(outputs=lambda C: C)
 def get_voigt_average(C):
     """
     Get the Voigt average of the elastic constants
@@ -180,6 +181,7 @@ def get_voigt_average(C):
     return dict(zip(["C_11", "C_12", "C_44"], tools.voigt_average(C_11, C_12, C_44)))
 
 
+@units(outputs=lambda C: C)
 def get_reuss_average(C):
     """
     Get the Reuss average of the elastic constants
@@ -251,6 +253,7 @@ def get_zener_ratio(C):
     return 2 * C_44 / (C_11 - C_12)
 
 
+@units(outputs=lambda C: C)
 def get_unique_elastic_constants(C):
     indices = np.sort(np.unique(np.round(C, decimals=8), return_index=True)[1])
     i, j = np.unravel_index(indices, (6, 6))
@@ -276,6 +279,7 @@ def get_elastic_moduli(C):
     }
 
 
+@units(outputs=lambda C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66, youngs_modulus, poissons_ratio, shear_modulus: optional_units(C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66, youngs_modulus, poissons_ratio, shear_modulus))
 def initialize_elastic_tensor(
     C_tensor=None,
     C_11=None,

--- a/elaston/elastic_constants.py
+++ b/elaston/elastic_constants.py
@@ -5,6 +5,7 @@
 import numpy as np
 from typing import Optional
 from elaston import tools
+from elaston.units import units, optional_units
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -55,6 +56,7 @@ def check_is_tensor(**kwargs):
     return False
 
 
+@units(outputs=lambda C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66: optional_units(C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66))
 def get_elastic_tensor_from_tensor(
     C_tensor: Optional[np.ndarray] = None,
     C_11: Optional[float] = None,
@@ -122,6 +124,7 @@ def get_elastic_tensor_from_tensor(
     )
 
 
+@units(outputs=lambda E, nu, mu: optional_units(E, nu, mu))
 def get_elastic_tensor_from_moduli(
     E: Optional[float] = None,
     nu: Optional[float] = None,

--- a/elaston/elastic_constants.py
+++ b/elaston/elastic_constants.py
@@ -164,7 +164,6 @@ def get_elastic_tensor_from_moduli(
     )
 
 
-@units(outputs=lambda C: C)
 def get_voigt_average(C):
     """
     Get the Voigt average of the elastic constants
@@ -181,7 +180,6 @@ def get_voigt_average(C):
     return dict(zip(["C_11", "C_12", "C_44"], tools.voigt_average(C_11, C_12, C_44)))
 
 
-@units(outputs=lambda C: C)
 def get_reuss_average(C):
     """
     Get the Reuss average of the elastic constants
@@ -253,7 +251,6 @@ def get_zener_ratio(C):
     return 2 * C_44 / (C_11 - C_12)
 
 
-@units(outputs=lambda C: C)
 def get_unique_elastic_constants(C):
     indices = np.sort(np.unique(np.round(C, decimals=8), return_index=True)[1])
     i, j = np.unravel_index(indices, (6, 6))
@@ -281,7 +278,6 @@ def get_elastic_moduli(C):
     }
 
 
-@units(outputs=lambda C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66, youngs_modulus, poissons_ratio, shear_modulus: optional_units(C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66, youngs_modulus, poissons_ratio, shear_modulus))
 def initialize_elastic_tensor(
     C_tensor=None,
     C_11=None,

--- a/elaston/elastic_constants.py
+++ b/elaston/elastic_constants.py
@@ -168,6 +168,7 @@ def get_elastic_tensor_from_moduli(
     )
 
 
+@units(outputs=lambda C: C.u)
 def get_voigt_average(C):
     """
     Get the Voigt average of the elastic constants
@@ -184,6 +185,7 @@ def get_voigt_average(C):
     return dict(zip(["C_11", "C_12", "C_44"], tools.voigt_average(C_11, C_12, C_44)))
 
 
+@units(outputs=lambda C: C.u)
 def get_reuss_average(C):
     """
     Get the Reuss average of the elastic constants

--- a/elaston/elastic_constants.py
+++ b/elaston/elastic_constants.py
@@ -56,7 +56,11 @@ def check_is_tensor(**kwargs):
     return False
 
 
-@units(outputs=lambda C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66: optional_units(C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66))
+@units(
+    outputs=lambda C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66: optional_units(
+        C_tensor, C_11, C_12, C_13, C_22, C_33, C_44, C_55, C_66
+    )
+)
 def get_elastic_tensor_from_tensor(
     C_tensor: Optional[np.ndarray] = None,
     C_11: Optional[float] = None,

--- a/elaston/tools.py
+++ b/elaston/tools.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import string
+from elaston.units import units
 
 
 __author__ = "Sam Waseda"
@@ -85,6 +86,7 @@ def index_from_voigt(i, j):
         return 6 - i - j
 
 
+@units(outputs=lambda C_in: C_in.u)
 def C_from_voigt(C_in, inverse=False):
     """
     Convert elastic tensor in Voigt notation to matrix notation.
@@ -109,6 +111,7 @@ def C_from_voigt(C_in, inverse=False):
     return C
 
 
+@units(outputs=lambda C_in: C_in.u)
 def C_to_voigt(C_in):
     """
     Convert elastic tensor in matrix notation to Voigt notation.

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -135,11 +135,13 @@ def units(outputs=None, inputs=None):
             ureg = _get_ureg(args, kwargs)
             if ureg is None:
                 return func(*args, **kwargs)
-            # This step unifies args and kwargs
-            kwargs.update(zip(inspect.getfullargspec(func).args, args))
+            signature = inspect.signature(func)
+            bound_args = signature.bind_partial(*args, **kwargs)
+            bound_args.apply_defaults()  # Fill in the default values
+            bound_args = dict(bound_args.arguments)
             if outputs is not None:
-                output_units = _get_output_units(outputs, kwargs, ureg)
-            result = func(**_pint_to_value(kwargs, inputs))
+                output_units = _get_output_units(outputs, bound_args, ureg)
+            result = func(**_pint_to_value(bound_args, inputs))
             if outputs is not None and output_units is not None:
                 if isinstance(output_units, Unit):
                     return result * output_units

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -91,7 +91,7 @@ def _get_output_units(outputs, kwargs, ureg):
 
     def f(out, kwargs=kwargs, ureg=ureg):
         if callable(out):
-            return extend_callable_with_kwargs(out(**kwargs))
+            return extend_callable_with_kwargs(out)(**kwargs)
         else:
             getattr(ureg, out)
 
@@ -99,7 +99,7 @@ def _get_output_units(outputs, kwargs, ureg):
         if callable(outputs) or isinstance(outputs, str):
             return f(outputs)
         if isinstance(outputs, (list, tuple)):
-            return tuple([f(outputs) for output in outputs])
+            return tuple([f(output) for output in outputs])
     except AttributeError as e:
         warnings.warn(
             "This function return an output with a relative unit. Either you"

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -135,13 +135,11 @@ def units(outputs=None, inputs=None):
             ureg = _get_ureg(args, kwargs)
             if ureg is None:
                 return func(*args, **kwargs)
-            signature = inspect.signature(func)
-            bound_args = signature.bind_partial(*args, **kwargs)
-            bound_args.apply_defaults()  # Fill in the default values
-            bound_args = dict(bound_args.arguments)
+            # This step unifies args and kwargs
+            kwargs.update(zip(inspect.getfullargspec(func).args, args))
             if outputs is not None:
-                output_units = _get_output_units(outputs, bound_args, ureg)
-            result = func(**_pint_to_value(bound_args, inputs))
+                output_units = _get_output_units(outputs, kwargs, ureg)
+            result = func(**_pint_to_value(kwargs, inputs))
             if outputs is not None and output_units is not None:
                 if isinstance(output_units, Unit):
                     return result * output_units

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -3,7 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 from pint import Quantity, Unit
-from inspect import getfullargspec
+import inspect
 import warnings
 
 __author__ = "Sam Waseda"
@@ -136,7 +136,7 @@ def units(outputs=None, inputs=None):
             if ureg is None:
                 return func(*args, **kwargs)
             # This step unifies args and kwargs
-            kwargs.update(zip(getfullargspec(func).args, args))
+            kwargs.update(zip(inspect.getfullargspec(func).args, args))
             if outputs is not None:
                 output_units = _get_output_units(outputs, kwargs, ureg)
             result = func(**_pint_to_value(kwargs, inputs))

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -90,15 +90,16 @@ def _get_output_units(outputs, kwargs, ureg):
     """
 
     def f(out, kwargs=kwargs, ureg=ureg):
-        return out(**kwargs) if callable(out) else getattr(ureg, out)
+        if callable(out):
+            return extend_callable_with_kwargs(out(**kwargs))
+        else:
+            getattr(ureg, out)
 
     try:
         if callable(outputs) or isinstance(outputs, str):
-            return f(extend_callable_with_kwargs(outputs))
+            return f(outputs)
         if isinstance(outputs, (list, tuple)):
-            return tuple(
-                [f(extend_callable_with_kwargs(outputs)) for output in outputs]
-            )
+            return tuple([f(outputs) for output in outputs])
     except AttributeError as e:
         warnings.warn(
             "This function return an output with a relative unit. Either you"

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -150,3 +150,10 @@ def units(outputs=None, inputs=None):
         return wrapper
 
     return decorator
+
+
+def optional_units(*args):
+    for arg in args:
+        if isinstance(arg, Quantity):
+            return arg.u
+    return 1

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,12 +1,10 @@
 import numpy as np
 import unittest
-from elaston.units import units
+from elaston.units import units, optional_units
 from pint import UnitRegistry
 
 
-@units(
-    inputs={"b": "angstrom", "x": "angstrom", "C": "GPa"}, outputs="GPa"
-)
+@units(inputs={"b": "angstrom", "x": "angstrom", "C": "GPa"}, outputs="GPa")
 def get_stress_absolute(b, x, C):
     return np.round(b / x * C, decimals=8)
 
@@ -26,46 +24,59 @@ def no_units(a):
     return a
 
 
+@units(
+    outputs=lambda distance, time, duration: distance.u / optional_units(time, duration)
+)
+def get_velocity(distance, time=None, duration=None):
+    if time is not None:
+        return distance / time
+    if duration is not None:
+        return distance / duration
+
+
 class TestTools(unittest.TestCase):
     def test_units(self):
         self.assertEqual(get_stress_absolute(1, 1, 1), 1)
         self.assertEqual(get_stress_relative(1, 1, 1), 1)
         ureg = UnitRegistry()
         self.assertEqual(
-            get_stress_absolute(
-                1 * ureg.angstrom, 1 * ureg.angstrom, 1 * ureg.GPa
-            ),
-            1 * ureg.GPa
+            get_stress_absolute(1 * ureg.angstrom, 1 * ureg.angstrom, 1 * ureg.GPa),
+            1 * ureg.GPa,
         )
         self.assertEqual(
-            get_stress_absolute(
-                1 * ureg.nanometer, 1 * ureg.angstrom, 1 * ureg.GPa
-            ),
-            10 * ureg.GPa
+            get_stress_absolute(1 * ureg.nanometer, 1 * ureg.angstrom, 1 * ureg.GPa),
+            10 * ureg.GPa,
         )
         self.assertEqual(
-            get_stress_relative(
-                1 * ureg.angstrom, 1 * ureg.angstrom, 1 * ureg.GPa
-            ),
-            1 * ureg.GPa
+            get_stress_relative(1 * ureg.angstrom, 1 * ureg.angstrom, 1 * ureg.GPa),
+            1 * ureg.GPa,
         )
         self.assertEqual(
-            get_stress_relative(
-                1 * ureg.nanometer, 1 * ureg.angstrom, 1 * ureg.GPa
-            ),
-            1 * ureg.nanometer / ureg.angstrom * ureg.GPa
+            get_stress_relative(1 * ureg.nanometer, 1 * ureg.angstrom, 1 * ureg.GPa),
+            1 * ureg.nanometer / ureg.angstrom * ureg.GPa,
         )
         with self.assertWarns(SyntaxWarning):
             get_stress_relative(1 * ureg.nanometer, 1 * ureg.angstrom, 1)
         self.assertEqual(
             get_multiple_outputs(1 * ureg.angstrom, 1 * ureg.angstrom),
-            (2 * ureg.angstrom, 1 * ureg.angstrom ** 2)
+            (2 * ureg.angstrom, 1 * ureg.angstrom**2),
         )
         with self.assertRaises(ValueError):
             # No relative output units and absolute input units at the same time
             units(outputs=lambda x: x.u, inputs={"x": "GPa"})
         self.assertEqual(no_units(1), 1)
         self.assertEqual(no_units(1 * ureg.angstrom), 1)
+
+    def test_optional_units(self):
+        ureg = UnitRegistry()
+        self.assertEqual(
+            get_velocity(distance=1 * ureg.angstrom, time=1 * ureg.second),
+            1 * ureg.angstrom / ureg.second,
+        )
+        self.assertEqual(
+            get_velocity(distance=1 * ureg.angstrom, duration=1 * ureg.second),
+            1 * ureg.angstrom / ureg.second,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I created the decorator `optional_units` when there are multiple arguments which could be used for the input argument. In this case the user is free to choose the elastic constants among `C_11`, `C_12`, `C_13`, `youngs_modulus` etc., and the ones that they don't specify will remain `None`, which obviously does not have a unit. In this case the algorithm automatically detects the variables with a unit and uses it as the output unit.