### PR TITLE
Extend units

### DIFF
--- a/elaston/units.py
+++ b/elaston/units.py
@@ -6,6 +6,7 @@ from pint import Quantity, Unit
 import inspect
 import warnings
 from functools import wraps
+from typing import Annotated, get_type_hints
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -126,7 +127,7 @@ def _check_inputs_and_outputs(inp, out):
             isinstance(out, (list, tuple)) and any(map(callable, out))
         ):
             raise ValueError(
-                "You cannot use relative output units when inpput units are defined"
+                "You cannot use relative output units when input units are defined"
             )
 
 
@@ -136,6 +137,27 @@ def _get_input_args(func, *args, **kwargs):
     bound_args.apply_defaults()  # Fill in the default values
     bound_args = dict(bound_args.arguments)
     return bound_args
+
+
+def get_units_from_type_hints(func):
+    return {
+        key: value.__metadata__[0]
+        for key, value in get_type_hints(func, include_extras=True).items()
+        if hasattr(value, "__metadata__")
+    }
+
+
+def get_input_units_from_type_hints(func):
+    d = get_units_from_type_hints(func)
+    if "return" in d:
+        del d["return"]
+    if len(d) == 0:
+        return None
+    return d
+
+
+def get_output_units_from_type_hints(func):
+    return get_units_from_type_hints(func).get("return", None)
 
 
 def units(outputs=None, inputs=None):
@@ -157,6 +179,11 @@ def units(outputs=None, inputs=None):
     _check_inputs_and_outputs(inputs, outputs)
 
     def decorator(func):
+        nonlocal inputs, outputs
+        if inputs is None:
+            inputs = get_input_units_from_type_hints(func)
+        if outputs is None:
+            outputs = get_output_units_from_type_hints(func)
         @wraps(func)
         def wrapper(*args, **kwargs):
             ureg = _get_ureg(args, kwargs)
@@ -183,3 +210,13 @@ def optional_units(*args):
         if isinstance(arg, Quantity):
             return arg.u
     return 1
+
+
+class Floats:
+    def __class_getitem__(cls, metadata):
+        return Annotated[float, metadata]
+
+
+class Ints:
+    def __class_getitem__(cls, metadata):
+        return Annotated[int, metadata]

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -184,6 +184,7 @@ def units(outputs=None, inputs=None):
             inputs = get_input_units_from_type_hints(func)
         if outputs is None:
             outputs = get_output_units_from_type_hints(func)
+
         @wraps(func)
         def wrapper(*args, **kwargs):
             ureg = _get_ureg(args, kwargs)

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -213,11 +213,11 @@ def optional_units(*args):
     return 1
 
 
-class Floats:
+class Float:
     def __class_getitem__(cls, metadata):
         return Annotated[float, metadata]
 
 
-class Ints:
+class Int:
     def __class_getitem__(cls, metadata):
         return Annotated[int, metadata]

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,20 +1,20 @@
 import numpy as np
 import unittest
-from elaston.units import units, optional_units, Floats, Ints
+from elaston.units import units, optional_units, Float, Int
 from pint import UnitRegistry
 
 
 @units()
 def get_speed_ints(
-    distance: Ints["meter"], time: Ints["second"]
-) -> Ints["meter/second"]:
+    distance: Int["meter"], time: Int["second"]
+) -> Int["meter/second"]:
     return distance / time
 
 
 @units()
 def get_speed_floats(
-    distance: Floats["meter"], time: Floats["second"]
-) -> Floats["meter/second"]:
+    distance: Float["meter"], time: Float["second"]
+) -> Float["meter/second"]:
     return distance / time
 
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,7 +1,21 @@
 import numpy as np
 import unittest
-from elaston.units import units, optional_units
+from elaston.units import units, optional_units, Floats, Ints
 from pint import UnitRegistry
+
+
+@units()
+def get_speed_ints(
+    distance: Ints["meter"], time: Ints["second"]
+) -> Ints["meter/second"]:
+    return distance / time
+
+
+@units()
+def get_speed_floats(
+    distance: Floats["meter"], time: Floats["second"]
+) -> Floats["meter/second"]:
+    return distance / time
 
 
 @units(inputs={"b": "angstrom", "x": "angstrom", "C": "GPa"}, outputs="GPa")
@@ -76,6 +90,17 @@ class TestTools(unittest.TestCase):
         self.assertEqual(
             get_velocity(distance=1 * ureg.angstrom, duration=1 * ureg.second),
             1 * ureg.angstrom / ureg.second,
+        )
+
+    def test_type_hinting(self):
+        self.assertEqual(get_speed_floats(1, 1), 1)
+        self.assertEqual(get_speed_ints(1, 1), 1)
+        ureg = UnitRegistry()
+        self.assertAlmostEqual(
+            get_speed_floats(1 * ureg.meter, 1 * ureg.millisecond).magnitude, 1e3
+        )
+        self.assertAlmostEqual(
+            get_speed_ints(1 * ureg.meter, 1 * ureg.millisecond).magnitude, int(1e3)
         )
 
 


### PR DESCRIPTION
Following a discussion with @jan-janssen and @JNmpi I implemented units with type hinting.

Example:

```python
from elaston.units import Float, units
from pint import UnitRegistry

@units()
def get_velocity(distance: Float["meter"], time: Float["second"]) -> Float["meter/second"]:
    return distance / time

ureg = UnitRegistry()

print(get_velocity(10 * ureg.angstrom, 1 * ureg.second))
```

Output: `1e-09 meter / second`