### PR TITLE
Allow multiple dispatch

### DIFF
--- a/elaston/units.py
+++ b/elaston/units.py
@@ -168,6 +168,7 @@ def units(func=None, *, outputs=None, inputs=None):
         # Return the actual decorator that expects the function
         def decorator(func):
             return _units_decorator(func, inputs, outputs)
+
         return decorator
     else:
         # The decorator is called without parentheses, so func is the actual function

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -4,6 +4,13 @@ from elaston.units import units, optional_units, Float, Int
 from pint import UnitRegistry
 
 
+@units
+def get_speed_multiple_dispatch(
+    distance: Float["meter"], time: Float["second"]
+) -> Float["meter/second"]:
+    return distance / time
+
+
 @units()
 def get_speed_ints(
     distance: Int["meter"], time: Int["second"]
@@ -101,6 +108,16 @@ class TestTools(unittest.TestCase):
         )
         self.assertAlmostEqual(
             get_speed_ints(1 * ureg.meter, 1 * ureg.millisecond).magnitude, int(1e3)
+        )
+
+    def test_multiple_dispatch(self):
+        ureg = UnitRegistry()
+        self.assertAlmostEqual(
+            get_speed_multiple_dispatch(1 * ureg.meter, 1 * ureg.second).magnitude, 1
+        )
+        self.assertAlmostEqual(
+            get_speed_multiple_dispatch(1 * ureg.meter, 1 * ureg.millisecond).magnitude,
+            1e3,
         )
 
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -12,9 +12,7 @@ def get_speed_multiple_dispatch(
 
 
 @units()
-def get_speed_ints(
-    distance: Int["meter"], time: Int["second"]
-) -> Int["meter/second"]:
+def get_speed_ints(distance: Int["meter"], time: Int["second"]) -> Int["meter/second"]:
     return distance / time
 
 


### PR DESCRIPTION
@liamhuber requested the feature [here](https://github.com/pyiron/elaston/pull/45)

```python
from elaston.units import Float, units
from pint import UnitRegistry

@units
def get_velocity(distance: Float["meter"], time: Float["second"]) -> Float["meter/second"]:
    return distance / time

ureg = UnitRegistry()

print(get_velocity(10 * ureg.angstrom, 1 * ureg.second))
```

Output: `1e-09 meter / second`

In short, now you can write either `units()` or `units`.