### PR TITLE
Include numpy array for type hinting

### DIFF
--- a/elaston/units.py
+++ b/elaston/units.py
@@ -7,6 +7,7 @@ import inspect
 import warnings
 from functools import wraps
 from typing import Annotated, get_type_hints
+import numpy as np
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -217,3 +218,8 @@ class Float:
 class Int:
     def __class_getitem__(cls, metadata):
         return Annotated[int, metadata]
+
+
+class Array:
+    def __class_getitem__(cls, metadata):
+        return Annotated[np.ndarray, metadata]

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,7 +1,14 @@
 import numpy as np
 import unittest
-from elaston.units import units, optional_units, Float, Int
+from elaston.units import units, optional_units, Float, Int, Array
 from pint import UnitRegistry
+
+
+@units
+def get_speed_array(
+    distance: Array["meter"], time: Array["second"]
+) -> Array["meter/second"]:
+    return distance / time
 
 
 @units
@@ -116,6 +123,16 @@ class TestTools(unittest.TestCase):
         self.assertAlmostEqual(
             get_speed_multiple_dispatch(1 * ureg.meter, 1 * ureg.millisecond).magnitude,
             1e3,
+        )
+
+    def get_speed_array(self):
+        ureg = UnitRegistry()
+        self.assertTrue(
+            np.all(
+                get_speed_array(
+                    np.array([1, 2, 3]) * ureg.meter, np.array([1, 2, 3]) * ureg.second
+                ).magnitude == np.array([1, 1, 1])
+            )
         )
 
 


### PR DESCRIPTION
Example:

```python
@units
def get_speed_array(distance: Array["meter"], time: Array["second"]) -> Array["meter/second"]:
    return distance / time
```