### PR TITLE
Allow optional and Union

### DIFF
--- a/elaston/units.py
+++ b/elaston/units.py
@@ -159,9 +159,7 @@ def get_metadata_if_annotated(tp):
 
     # Handle generic types like List, Dict, Tuple, etc.
     elif origin in {list, dict, tuple}:
-        raise NotImplementedError(
-            f"Generic types like {origin} are not supported yet."
-        )
+        raise NotImplementedError(f"Generic types like {origin} are not supported yet.")
         # for arg in get_args(tp):
         #     metadata = get_metadata_if_annotated(arg)
         #     if metadata:

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -159,7 +159,9 @@ def get_metadata_if_annotated(tp):
 
     # Handle generic types like List, Dict, Tuple, etc.
     elif origin in {list, dict, tuple}:
-        raise NotImplementedError(f"Generic types like {origin} are not supported yet.")
+        pass
+        # Following code would in principle work but is commented out for now
+        # as long as it is not clear how to deal with the actual values
         # for arg in get_args(tp):
         #     metadata = get_metadata_if_annotated(arg)
         #     if metadata:

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -6,8 +6,7 @@ from pint import Quantity, Unit
 import inspect
 import warnings
 from functools import wraps
-from typing import Annotated, get_type_hints
-from typing import Optional, Annotated, Union, get_args, get_origin
+from typing import Annotated, Union, get_args, get_origin, get_type_hints
 
 import numpy as np
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -9,7 +9,7 @@ from pint import UnitRegistry
 def get_speed_optional_union(
     distance: Union[Float["meter"], Array["meter"]],
     time: Union[Float["second"], Array["second"]],
-    duration: Optional[Union[Float["second"], Array["second"]]]
+    duration: Optional[Union[Float["second"], Array["second"]]],
 ) -> Union[Float["meter/second"], Array["meter/second"]]:
     if duration is not None:
         return distance / duration
@@ -28,7 +28,7 @@ def get_speed_optional(
 @units
 def get_speed_union(
     distance: Union[Float["meter"], Array["meter"]],
-    time: Union[Float["second"], Array["second"]]
+    time: Union[Float["second"], Array["second"]],
 ) -> Union[Float["meter/second"], Array["meter/second"]]:
     return distance / time
 
@@ -160,7 +160,8 @@ class TestUnits(unittest.TestCase):
             np.all(
                 get_speed_array(
                     np.array([1, 2, 3]) * ureg.meter, np.array([1, 2, 3]) * ureg.second
-                ).magnitude == np.array([1, 1, 1])
+                ).magnitude
+                == np.array([1, 1, 1])
             )
         )
 
@@ -173,38 +174,45 @@ class TestUnits(unittest.TestCase):
             np.all(
                 get_speed_union(
                     np.array([1, 2, 3]) * ureg.meter, np.array([1, 2, 3]) * ureg.second
-                ).magnitude == np.array([1, 1, 1])
+                ).magnitude
+                == np.array([1, 1, 1])
             )
         )
 
     def test_optional(self):
         ureg = UnitRegistry()
         self.assertAlmostEqual(
-            get_speed_optional(1 * ureg.meter, 1 * ureg.second, 1 * ureg.second).magnitude,
-            1
+            get_speed_optional(
+                1 * ureg.meter, 1 * ureg.second, 1 * ureg.second
+            ).magnitude,
+            1,
         )
         self.assertAlmostEqual(
-            get_speed_optional(1 * ureg.meter, 1 * ureg.second, None).magnitude,
-            1
+            get_speed_optional(1 * ureg.meter, 1 * ureg.second, None).magnitude, 1
         )
         self.assertAlmostEqual(
-            get_speed_optional(1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond).magnitude,
-            1e3
+            get_speed_optional(
+                1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond
+            ).magnitude,
+            1e3,
         )
 
     def test_optional_union(self):
         ureg = UnitRegistry()
         self.assertAlmostEqual(
-            get_speed_optional_union(1 * ureg.meter, 1 * ureg.second, 1 * ureg.second).magnitude,
-            1
+            get_speed_optional_union(
+                1 * ureg.meter, 1 * ureg.second, 1 * ureg.second
+            ).magnitude,
+            1,
         )
         self.assertAlmostEqual(
-            get_speed_optional_union(1 * ureg.meter, 1 * ureg.second, None).magnitude,
-            1
+            get_speed_optional_union(1 * ureg.meter, 1 * ureg.second, None).magnitude, 1
         )
         self.assertAlmostEqual(
-            get_speed_optional_union(1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond).magnitude,
-            1e3
+            get_speed_optional_union(
+                1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond
+            ).magnitude,
+            1e3,
         )
 
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -6,6 +6,17 @@ from pint import UnitRegistry
 
 
 @units
+def get_speed_optional_union(
+    distance: Union[Float["meter"], Array["meter"]],
+    time: Union[Float["second"], Array["second"]],
+    duration: Optional[Union[Float["second"], Array["second"]]]
+) -> Union[Float["meter/second"], Array["meter/second"]]:
+    if duration is not None:
+        return distance / duration
+    return distance / time
+
+
+@units
 def get_speed_optional(
     distance: Float["meter"], time: Float["second"], duration: Optional[Float["second"]]
 ) -> Float["meter/second"]:
@@ -178,6 +189,21 @@ class TestUnits(unittest.TestCase):
         )
         self.assertAlmostEqual(
             get_speed_optional(1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond).magnitude,
+            1e3
+        )
+
+    def test_optional_union(self):
+        ureg = UnitRegistry()
+        self.assertAlmostEqual(
+            get_speed_optional_union(1 * ureg.meter, 1 * ureg.second, 1 * ureg.second).magnitude,
+            1
+        )
+        self.assertAlmostEqual(
+            get_speed_optional_union(1 * ureg.meter, 1 * ureg.second, None).magnitude,
+            1
+        )
+        self.assertAlmostEqual(
+            get_speed_optional_union(1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond).magnitude,
             1e3
         )
 


### PR DESCRIPTION
Example

```python
@units
def get_speed_optional(
    distance: Float["meter"], time: Float["second"], duration: Optional[Float["second"]]
) -> Float["meter/second"]:
    if duration is not None:
        return distance / duration
    return distance / time


@units
def get_speed_union(
    distance: Union[Float["meter"], Array["meter"]],
    time: Union[Float["second"], Array["second"]]
) -> Union[Float["meter/second"], Array["meter/second"]]:
    return distance / time
```