### PR TITLE
Allow arbitrary type hints by wrapping them

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,3 +5,4 @@ dependencies:
 - coverage
 - numpy =2.0.1
 - pint=0.24.3
+- pyiron_snippets=0.1.4

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -4,5 +4,5 @@ dependencies:
 - coveralls
 - coverage
 - numpy =2.0.1
-- pint=0.24.3
-- pyiron_snippets=0.1.4
+- pint =0.24.3
+- pyiron_snippets =0.1.4

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,3 +5,4 @@ dependencies:
 - coverage
 - numpy =2.0.1
 - pint=0.24.3
+- pyiron_snippets=0.1.4

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -4,5 +4,5 @@ dependencies:
 - coveralls
 - coverage
 - numpy =2.0.1
-- pint=0.24.3
-- pyiron_snippets=0.1.4
+- pint =0.24.3
+- pyiron_snippets =0.1.4

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,5 +10,5 @@ dependencies:
 - coveralls
 - coverage
 - numpy =2.0.1
-- pint=0.24.3
-- pyiron_snippets=0.1.4
+- pint =0.24.3
+- pyiron_snippets =0.1.4

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,3 +11,4 @@ dependencies:
 - coverage
 - numpy =2.0.1
 - pint=0.24.3
+- pyiron_snippets=0.1.4

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -2,11 +2,14 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from pint import Quantity, Unit
-import inspect
-import warnings
+from abc import ABC
 from functools import wraps
-from typing import Annotated, get_type_hints
+import inspect
+from typing import Annotated, Any, ClassVar, get_type_hints
+import warnings
+
+from pint import Quantity, Unit
+from pyiron_snippets.factory import classfactory, sanitize_callable_name
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -209,11 +212,18 @@ def optional_units(*args):
     return 1
 
 
-class Float:
+class HasUnits(ABC):
+    _hint: ClassVar[Any]
+
     def __class_getitem__(cls, metadata):
-        return Annotated[float, metadata]
+        return Annotated[cls._hint, metadata]
 
 
-class Int:
-    def __class_getitem__(cls, metadata):
-        return Annotated[int, metadata]
+@classfactory
+def u(hint, /):
+    return (
+        sanitize_callable_name(str(hint)),
+        (HasUnits,),
+        {"_hint": hint},
+        {},
+    )

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -2,6 +2,8 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
+from __future__ import annotations
+
 from abc import ABC
 from functools import wraps
 import inspect

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -218,20 +218,6 @@ class HasUnits(ABC):
     def __class_getitem__(cls, metadata):
         return Annotated[cls._hint, metadata]
 
-    def __getitem__(self, unit):
-        # The subscript method for handling unit strings
-        if not isinstance(unit, str):
-            raise TypeError("Unit must be a string.")
-        # Return a new instance or perform any specific behavior you want
-        return self.base_type_with_unit(unit)
-
-    def base_type_with_unit(self, unit):
-        # Placeholder for an actual implementation.
-        # This could, for example, return a custom type or a decorated function
-        # that incorporates the unit information.
-        return f"{self.base_type.__name__} with unit '{unit}'"
-
-
 
 @classfactory
 def u(hint, /):

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -218,6 +218,20 @@ class HasUnits(ABC):
     def __class_getitem__(cls, metadata):
         return Annotated[cls._hint, metadata]
 
+    def __getitem__(self, unit):
+        # The subscript method for handling unit strings
+        if not isinstance(unit, str):
+            raise TypeError("Unit must be a string.")
+        # Return a new instance or perform any specific behavior you want
+        return self.base_type_with_unit(unit)
+
+    def base_type_with_unit(self, unit):
+        # Placeholder for an actual implementation.
+        # This could, for example, return a custom type or a decorated function
+        # that incorporates the unit information.
+        return f"{self.base_type.__name__} with unit '{unit}'"
+
+
 
 @classfactory
 def u(hint, /):

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -124,22 +124,28 @@ class TestTools(unittest.TestCase):
     def test_optional_arg(self):
         ureg = UnitRegistry()
         self.assertAlmostEqual(
-            get_speed_optional_arg(1 * ureg.meter, 1 * ureg.second).magnitude, 1
+            get_speed_optional_arg(1 * ureg.meter, 1 * ureg.second).magnitude,
+            1/1,
+            msg="Optional None kwarg should be ignored."
         )
         self.assertAlmostEqual(
             get_speed_optional_arg(
-                1 * ureg.meter, 1 * ureg.second, 1 * ureg.second
+                1 * ureg.meter, 1 * ureg.second, 2 * ureg.second
             ).magnitude,
-            1,
+            1/2,
+            msg="Optional kwarg should take precedence."
         )
         self.assertAlmostEqual(
-            get_speed_optional_arg(1 * ureg.meter, 1 * ureg.millisecond).magnitude, 1e3
+            get_speed_optional_arg(1 * ureg.meter, 1 * ureg.millisecond).magnitude,
+            1/1e-3,
+            msg="Alternative units on standard arg should compute."
         )
         self.assertAlmostEqual(
             get_speed_optional_arg(
-                1 * ureg.meter, 1 * ureg.millisecond, 1 * ureg.millisecond
+                1 * ureg.meter, 1 * ureg.millisecond, 2 * ureg.millisecond
             ).magnitude,
-            1e3,
+            1/2e-3,
+            msg="Alternative units from preferred optional kwarg should compute."
         )
 
 


### PR DESCRIPTION
As an alternative to #47 and #48. This allows us to bypass defining any special types, but instead users just decorate their type hint and follow the same pattern of square brackets to assign units to it.

E.g.:

```python
import inspect

from elaston.units import units, u
import numpy as np
from pint import UnitRegistry
    
ureg = UnitRegistry()
r = np.arange(5)

@units
def get_speed_composite(
    distance: u(np.ndarray[float])["meter"], 
    time: u(np.ndarray[float])["second"]
) -> u(np.ndarray[float])["meter/second"]:
    return distance / time
    
print(inspect.signature(get_speed_composite).parameters["distance"].annotation)
# typing.Annotated[numpy.ndarray[float], 'meter']
print(get_speed_composite(r * ureg.angstrom, (r + 1) * ureg.seconds))
# [0.0 5e-11 6.666666666666667e-11 7.5e-11 8.000000000000001e-11] meter / second

@units
def get_speed_union(
    distance: u(int | float)["meter"], 
    time: u(int | float)["second"]
) -> u(np.ndarray[float])["meter/second"]:
    return distance / time

print(inspect.signature(get_speed_union).parameters["distance"].annotation)
# typing.Annotated[int | float, 'meter']
print(get_speed_composite(5 * ureg.angstrom, 3.14 * ureg.seconds))
# 1.5923566878980892e-10 meter / second
```

The type hint is preserved nicely just like your other work and is compatible with the bleeding edge of `pyiron_workflow`:

```python
from elaston.units import units, u
from pint import UnitRegistry
from pyiron_workflow import Workflow


@Workflow.wrap.as_function_node
@units
def GetSpeed(
    distance: u(int | float)["meter"], 
    time: u(int | float)["second"]
) -> u(int | float)["meter/second"]:
    return distance / time

ureg = UnitRegistry()

n = GetSpeed()

try:
    n("this is not a number", 10)
except TypeError as e:
    print(e)
# The channel /GetSpeed.distance cannot take the value `this is not a number` (<class 'str'>) because it is not compliant with the type hint int | float

n(5 * ureg.angstrom, 3.14 * ureg.seconds)
# 1.5923566878980892×10-10 meter/second

```

Good names, unit tests, and checking for edge cases are all exercises left to the reader 😜 