### PR TITLE
Units with onto

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -12,5 +12,4 @@ jobs:
     uses: pyiron/actions/.github/workflows/push-pull.yml@actions-3.2.1
     with:
       python-version-alt3: 'exclude'  # No python 3.9
-      python-version-alt2: 'exclude'  # No python 3.10
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -12,4 +12,5 @@ jobs:
     uses: pyiron/actions/.github/workflows/push-pull.yml@actions-3.2.1
     with:
       python-version-alt3: 'exclude'  # No python 3.9
+      python-version-alt2: 'exclude'  # No python 3.10
     secrets: inherit

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -6,7 +6,7 @@ from pint import Quantity, Unit
 import inspect
 import warnings
 from functools import wraps
-from typing import Annotated, get_type_hints
+from typing import Annotated, get_type_hints, Any
 from abc import ABC
 
 __author__ = "Sam Waseda"
@@ -217,5 +217,5 @@ def optional_units(*args):
     return 1
 
 
-def u(type_, /, units: str | None = None):
-    return Annotated[type_, {"units": units}]
+def u(type_, /, units: str | None = None, otype: Any = None):
+    return Annotated[type_, {"units": units, "otype": otype}]

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -218,4 +218,4 @@ def optional_units(*args):
 
 
 def u(type_, /, units: str | None = None, otype: Any = None):
-    return Annotated[type_, {"units": units, "otype": otype}]
+    return Annotated[type_, frozenset({"units": units, "otype": otype})]

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -217,16 +217,6 @@ def optional_units(*args):
     return 1
 
 
-class Float:
-    def __class_getitem__(cls, metadata):
-        return Annotated[float, metadata]
-
-
-class Int:
-    def __class_getitem__(cls, metadata):
-        return Annotated[int, metadata]
-
-
 class OntoType(ABC):
     pass
 

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -141,7 +141,7 @@ def _get_input_args(func, *args, **kwargs):
 
 def get_units_from_type_hints(func):
     return {
-        key: dict(value.__metadata__[0])["units"]
+        key: value.__metadata__[0]
         for key, value in get_type_hints(func, include_extras=True).items()
         if hasattr(value, "__metadata__")
     }
@@ -210,4 +210,4 @@ def optional_units(*args):
 
 
 def u(type_, /, units: str | None = None, otype: Any = None):
-    return Annotated[type_, frozenset({"units": units, "otype": otype}.items())]
+    return Annotated[type_, units, otype]

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -140,16 +140,9 @@ def _get_input_args(func, *args, **kwargs):
     return bound_args
 
 
-def _dict_or_item(d):
-    if isinstance(d, dict) and "units" in d:
-        return d["units"]
-    elif isinstance(d, str):
-        return d
-
-
 def get_units_from_type_hints(func):
     return {
-        key: _dict_or_item(value.__metadata__[0])
+        key: dict(value.__metadata__[0])["units"]
         for key, value in get_type_hints(func, include_extras=True).items()
         if hasattr(value, "__metadata__")
     }
@@ -218,4 +211,4 @@ def optional_units(*args):
 
 
 def u(type_, /, units: str | None = None, otype: Any = None):
-    return Annotated[type_, frozenset({"units": units, "otype": otype})]
+    return Annotated[type_, frozenset({"units": units, "otype": otype}.items())]

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -7,7 +7,6 @@ import inspect
 import warnings
 from functools import wraps
 from typing import Annotated, get_type_hints, Any
-from abc import ABC
 
 __author__ = "Sam Waseda"
 __copyright__ = (

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -7,6 +7,7 @@ import inspect
 import warnings
 from functools import wraps
 from typing import Annotated, get_type_hints
+from abc import ABC
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -139,9 +140,16 @@ def _get_input_args(func, *args, **kwargs):
     return bound_args
 
 
+def _dict_or_item(d):
+    if isinstance(d, dict) and "units" in d:
+        return d["units"]
+    elif isinstance(d, str):
+        return d
+
+
 def get_units_from_type_hints(func):
     return {
-        key: value.__metadata__[0]
+        key: _dict_or_item(value.__metadata__[0])
         for key, value in get_type_hints(func, include_extras=True).items()
         if hasattr(value, "__metadata__")
     }
@@ -217,3 +225,11 @@ class Float:
 class Int:
     def __class_getitem__(cls, metadata):
         return Annotated[int, metadata]
+
+
+class OntoType(ABC):
+    pass
+
+
+def u(type_, /, units: str | None = None, otype: OntoType | None = None):
+    return Annotated[type_, {"units": units, "otype": otype}]

--- a/elaston/units.py
+++ b/elaston/units.py
@@ -217,9 +217,5 @@ def optional_units(*args):
     return 1
 
 
-class OntoType(ABC):
-    pass
-
-
-def u(type_, /, units: str | None = None, otype: OntoType | None = None):
-    return Annotated[type_, {"units": units, "otype": otype}]
+def u(type_, /, units: str | None = None):
+    return Annotated[type_, {"units": units}]

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -8,7 +8,7 @@ from pint import UnitRegistry
 def get_speed_onto_optional_args(
     distance: u(float, "meter"),
     time: u(float, "second"),
-    duration: u(float | None, "second") = None,
+    duration: u(float, "second") = 3,
 ) -> u(float, "meter/second"):
     if duration is not None:
         return distance / duration

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -8,7 +8,7 @@ from pint import UnitRegistry
 def get_speed_onto_optional_args(
     distance: u(float, "meter"),
     time: u(float, "second"),
-    duration: u(float, "second") = 1,
+    duration: u(float | None, "second") = 1,
 ) -> u(float, "meter/second"):
     if duration != 1:
         return distance / duration

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -8,9 +8,9 @@ from pint import UnitRegistry
 def get_speed_onto_optional_args(
     distance: u(float, "meter"),
     time: u(float, "second"),
-    duration: u(float, "second") = 3,
+    duration: u(float, "second") = 1,
 ) -> u(float, "meter/second"):
-    if duration is not None:
+    if duration != 1:
         return distance / duration
     return distance / time
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -10,6 +10,7 @@ def get_speed_onto(
 ) -> u(float, "meter/second"):
     return distance / time
 
+
 @units
 def get_speed_multiple_dispatch(
     distance: Float["meter"], time: Float["second"]

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,8 +1,14 @@
 import numpy as np
 import unittest
-from elaston.units import units, optional_units, Float, Int
+from elaston.units import units, optional_units, Float, Int, u
 from pint import UnitRegistry
 
+
+@units
+def get_speed_onto(
+    distance: u(float, "meter"), time: u(float, "second")
+) -> u(float, "meter/second"):
+    return distance / time
 
 @units
 def get_speed_multiple_dispatch(
@@ -116,6 +122,15 @@ class TestTools(unittest.TestCase):
         self.assertAlmostEqual(
             get_speed_multiple_dispatch(1 * ureg.meter, 1 * ureg.millisecond).magnitude,
             1e3,
+        )
+
+    def test_onto(self):
+        ureg = UnitRegistry()
+        self.assertAlmostEqual(
+            get_speed_onto(1 * ureg.meter, 1 * ureg.second).magnitude, 1
+        )
+        self.assertAlmostEqual(
+            get_speed_onto(1 * ureg.meter, 1 * ureg.millisecond).magnitude, 1e3
         )
 
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -8,9 +8,9 @@ from pint import UnitRegistry
 def get_speed_onto_optional_args(
     distance: u(float, "meter"),
     time: u(float, "second"),
-    duration: u(float | None, "second") = 1,
+    duration: u(float | None, "second") = None,
 ) -> u(float, "meter/second"):
-    if duration != 1:
+    if duration is not None:
         return distance / duration
     return distance / time
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -5,6 +5,17 @@ from pint import UnitRegistry
 
 
 @units
+def get_speed_onto_optional_args(
+    distance: u(float, "meter"),
+    time: u(float, "second"),
+    duration: u(float | None, "second") = None,
+) -> u(float, "meter/second"):
+    if duration is not None:
+        return distance / duration
+    return distance / time
+
+
+@units
 def get_speed_onto(
     distance: u(float, "meter"), time: u(float, "second")
 ) -> u(float, "meter/second"):
@@ -132,6 +143,30 @@ class TestTools(unittest.TestCase):
         )
         self.assertAlmostEqual(
             get_speed_onto(1 * ureg.meter, 1 * ureg.millisecond).magnitude, 1e3
+        )
+
+    def test_onto_optional_args(self):
+        ureg = UnitRegistry()
+        self.assertAlmostEqual(
+            get_speed_onto_optional_args(1 * ureg.meter, 1 * ureg.second).magnitude, 1
+        )
+        self.assertAlmostEqual(
+            get_speed_onto_optional_args(
+                1 * ureg.meter, 1 * ureg.millisecond
+            ).magnitude,
+            1e3,
+        )
+        self.assertAlmostEqual(
+            get_speed_onto_optional_args(
+                1 * ureg.meter, 1 * ureg.second, 1 * ureg.second
+            ).magnitude,
+            1,
+        )
+        self.assertAlmostEqual(
+            get_speed_onto_optional_args(
+                1 * ureg.meter, 1 * ureg.millisecond, 1 * ureg.millisecond
+            ).magnitude,
+            1e3,
         )
 
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -8,7 +8,7 @@ from pint import UnitRegistry
 def get_speed_onto_optional_args(
     distance: u(float, "meter"),
     time: u(float, "second"),
-    duration: u(float | None, "second") = None,
+    duration: u(float | None, units="second") = None,
 ) -> u(float, "meter/second"):
     if duration is not None:
         return distance / duration

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,6 +1,6 @@
 import numpy as np
 import unittest
-from elaston.units import units, optional_units, Float, Int, u
+from elaston.units import units, optional_units, u
 from pint import UnitRegistry
 
 
@@ -19,25 +19,6 @@ def get_speed_onto_optional_args(
 def get_speed_onto(
     distance: u(float, "meter"), time: u(float, "second")
 ) -> u(float, "meter/second"):
-    return distance / time
-
-
-@units
-def get_speed_multiple_dispatch(
-    distance: Float["meter"], time: Float["second"]
-) -> Float["meter/second"]:
-    return distance / time
-
-
-@units()
-def get_speed_ints(distance: Int["meter"], time: Int["second"]) -> Int["meter/second"]:
-    return distance / time
-
-
-@units()
-def get_speed_floats(
-    distance: Float["meter"], time: Float["second"]
-) -> Float["meter/second"]:
     return distance / time
 
 
@@ -113,27 +94,6 @@ class TestTools(unittest.TestCase):
         self.assertEqual(
             get_velocity(distance=1 * ureg.angstrom, duration=1 * ureg.second),
             1 * ureg.angstrom / ureg.second,
-        )
-
-    def test_type_hinting(self):
-        self.assertEqual(get_speed_floats(1, 1), 1)
-        self.assertEqual(get_speed_ints(1, 1), 1)
-        ureg = UnitRegistry()
-        self.assertAlmostEqual(
-            get_speed_floats(1 * ureg.meter, 1 * ureg.millisecond).magnitude, 1e3
-        )
-        self.assertAlmostEqual(
-            get_speed_ints(1 * ureg.meter, 1 * ureg.millisecond).magnitude, int(1e3)
-        )
-
-    def test_multiple_dispatch(self):
-        ureg = UnitRegistry()
-        self.assertAlmostEqual(
-            get_speed_multiple_dispatch(1 * ureg.meter, 1 * ureg.second).magnitude, 1
-        )
-        self.assertAlmostEqual(
-            get_speed_multiple_dispatch(1 * ureg.meter, 1 * ureg.millisecond).magnitude,
-            1e3,
         )
 
     def test_onto(self):


### PR DESCRIPTION
Now I implemented what @liamhuber and I talked about.

```python
@units
def get_speed_onto(
    distance: u(float, "meter"), time: u(float, "second")
) -> u(float, "meter/second"):
    return distance / time
```

The functionality is the same as shown in the previous PRs. What happens internally is:

```python
print(u(float, "meter/second"))
```

Output: `typing.Annotated[float, {'units': 'meter/second', 'otype': None}]`

And it's up to the parser to figure out what to do with the additional information.