### PR TITLE
Remove type hinting just in case

### DIFF
--- a/elaston/units.py
+++ b/elaston/units.py
@@ -207,13 +207,3 @@ def optional_units(*args):
         if isinstance(arg, Quantity):
             return arg.u
     return 1
-
-
-class Float:
-    def __class_getitem__(cls, metadata):
-        return Annotated[float, metadata]
-
-
-class Int:
-    def __class_getitem__(cls, metadata):
-        return Annotated[int, metadata]

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,26 +1,7 @@
 import numpy as np
 import unittest
-from elaston.units import units, optional_units, Float, Int
+from elaston.units import units, optional_units
 from pint import UnitRegistry
-
-
-@units
-def get_speed_multiple_dispatch(
-    distance: Float["meter"], time: Float["second"]
-) -> Float["meter/second"]:
-    return distance / time
-
-
-@units()
-def get_speed_ints(distance: Int["meter"], time: Int["second"]) -> Int["meter/second"]:
-    return distance / time
-
-
-@units()
-def get_speed_floats(
-    distance: Float["meter"], time: Float["second"]
-) -> Float["meter/second"]:
-    return distance / time
 
 
 @units(inputs={"b": "angstrom", "x": "angstrom", "C": "GPa"}, outputs="GPa")
@@ -95,27 +76,6 @@ class TestTools(unittest.TestCase):
         self.assertEqual(
             get_velocity(distance=1 * ureg.angstrom, duration=1 * ureg.second),
             1 * ureg.angstrom / ureg.second,
-        )
-
-    def test_type_hinting(self):
-        self.assertEqual(get_speed_floats(1, 1), 1)
-        self.assertEqual(get_speed_ints(1, 1), 1)
-        ureg = UnitRegistry()
-        self.assertAlmostEqual(
-            get_speed_floats(1 * ureg.meter, 1 * ureg.millisecond).magnitude, 1e3
-        )
-        self.assertAlmostEqual(
-            get_speed_ints(1 * ureg.meter, 1 * ureg.millisecond).magnitude, int(1e3)
-        )
-
-    def test_multiple_dispatch(self):
-        ureg = UnitRegistry()
-        self.assertAlmostEqual(
-            get_speed_multiple_dispatch(1 * ureg.meter, 1 * ureg.second).magnitude, 1
-        )
-        self.assertAlmostEqual(
-            get_speed_multiple_dispatch(1 * ureg.meter, 1 * ureg.millisecond).magnitude,
-            1e3,
         )
 
 


### PR DESCRIPTION
I don't think there's imminent danger, but since the development was moved to [this directory](https://github.com/pyiron/uniton), I remove the additional types from here.