### PR TITLE
Get rid of elaston units

### DIFF
--- a/elaston/dislocation.py
+++ b/elaston/dislocation.py
@@ -221,7 +221,7 @@ def get_dislocation_energy(
     elastic_tensor: u(np.ndarray, units="=e"),
     burgers_vector: u(np.ndarray, units="=b"),
     r_min: float,
-    r_max: float
+    r_max: float,
     mesh: int = 100,
 ) -> u(float, units="=e*b**2"):
     """

--- a/elaston/dislocation.py
+++ b/elaston/dislocation.py
@@ -151,7 +151,7 @@ def get_dislocation_displacement(
 @units
 def get_dislocation_strain(
     elastic_tensor: np.ndarray,
-    positions: u(np.ndarray units="=p"),
+    positions: u(np.ndarray, units="=p"),
     burgers_vector: u(np.ndarray, units="=b"),
 ) -> u(np.ndarray, units="=b/p"):
     """

--- a/elaston/dislocation.py
+++ b/elaston/dislocation.py
@@ -4,8 +4,8 @@
 
 import numpy as np
 from functools import cached_property
-
-from elaston.units import units
+from semantikon.typing import u
+from semantikon.converter import units
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -126,12 +126,12 @@ class Dislocation:
         return strain / 4 / np.pi
 
 
-@units(outputs=lambda burgers_vector: burgers_vector.u)
+@units
 def get_dislocation_displacement(
     elastic_tensor: np.ndarray,
     positions: np.ndarray,
-    burgers_vector: np.ndarray,
-):
+    burgers_vector: u(np.ndarray, units="=b"),
+) -> u(np.ndarray, units="=b"):
     """
     Displacement field around a dislocation according to anisotropic elasticity theory
     described by [Eshelby](https://doi.org/10.1016/0001-6160(53)90099-6).
@@ -148,12 +148,12 @@ def get_dislocation_displacement(
     return Dislocation(elastic_tensor, burgers_vector).get_displacement(positions)
 
 
-@units(outputs=lambda burgers_vector, positions: burgers_vector.u / positions.u)
+@units
 def get_dislocation_strain(
     elastic_tensor: np.ndarray,
-    positions: np.ndarray,
-    burgers_vector: np.ndarray,
-):
+    positions: u(np.ndarray units="=p"),
+    burgers_vector: u(np.ndarray, units="=b"),
+) -> u(np.ndarray, units="=b/p"):
     """
     Strain field around a dislocation according to anisotropic elasticity theory
     described by [Eshelby](https://doi.org/10.1016/0001-6160(53)90099-6).
@@ -170,16 +170,12 @@ def get_dislocation_strain(
     return Dislocation(elastic_tensor, burgers_vector).get_strain(positions)
 
 
-@units(
-    outputs=lambda elastic_tensor, burgers_vector, positions: elastic_tensor.u
-    * burgers_vector.u
-    / positions.u
-)
+@units
 def get_dislocation_stress(
-    elastic_tensor: np.ndarray,
-    positions: np.ndarray,
-    burgers_vector: np.ndarray,
-):
+    elastic_tensor: u(np.ndarray, units="=e"),
+    positions: u(np.ndarray, units="=p"),
+    burgers_vector: u(np.ndarray, units="=b"),
+) -> u(np.ndarray, units="=e*b/p"):
     """
     Stress field around a dislocation according to anisotropic elasticity theory
     described by [Eshelby](https://doi.org/10.1016/0001-6160(53)90099-6).
@@ -197,16 +193,12 @@ def get_dislocation_stress(
     return np.einsum("ijkl,...kl->...ij", elastic_tensor, strain)
 
 
-@units(
-    outputs=lambda elastic_tensor, burgers_vector, positions: elastic_tensor.u
-    * burgers_vector.u**2
-    / positions.u**2
-)
+@units
 def get_dislocation_energy_density(
-    elastic_tensor: np.ndarray,
-    positions: np.ndarray,
-    burgers_vector: np.ndarray,
-):
+    elastic_tensor: u(np.ndarray, units="=e"),
+    positions: u(np.ndarray, units="=p"),
+    burgers_vector: u(np.ndarray, units="=b"),
+) -> u(np.ndarray, units="=e*b**2/p**2"):
     """
     Energy density field around a dislocation (product of stress and strain, cf. corresponding
     methods)
@@ -224,19 +216,14 @@ def get_dislocation_energy_density(
     return np.einsum("ijkl,...kl,...ij->...", elastic_tensor, strain, strain)
 
 
-@units(
-    outputs=lambda elastic_tensor, burgers_vector, positions, r_min: elastic_tensor.u
-    * burgers_vector.u**2
-    / positions.u**2
-    * r_min.u**2
-)
+@units
 def get_dislocation_energy(
-    elastic_tensor: np.ndarray,
-    burgers_vector: np.ndarray,
+    elastic_tensor: u(np.ndarray, units="=e"),
+    burgers_vector: u(np.ndarray, units="=b"),
     r_min: float,
-    r_max: float,
+    r_max: float
     mesh: int = 100,
-):
+) -> u(float, units="=e*b**2"):
     """
     Energy per unit length along the dislocation line.
 
@@ -281,12 +268,12 @@ def get_dislocation_energy(
     )
 
 
-@units(outputs=lambda stress, burgers_vector: stress.u * burgers_vector.u)
+@units
 def get_dislocation_force(
-    stress: np.ndarray,
+    stress: u(np.ndarray, units="=s"),
     glide_plane: np.ndarray,
-    burgers_vector: np.ndarray,
-):
+    burgers_vector: u(np.ndarray, units="=b"),
+) -> u(np.ndarray, units="=s*b"):
     """
     Force per unit length along the dislocation line.
 

--- a/elaston/inclusion.py
+++ b/elaston/inclusion.py
@@ -5,7 +5,7 @@
 import numpy as np
 from elaston.green import get_greens_function
 from semantikon.typing import u
-from semantikon.converter import units as semantikon_units
+from semantikon.converter import units
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -84,7 +84,7 @@ Vol. 1. Elsevier, 2012.
 """
 
 
-@semantikon_units
+@units
 def get_point_defect_displacement(
     C: u(np.ndarray, units="=C"),
     x: u(np.ndarray, units="=x"),
@@ -122,7 +122,7 @@ def get_point_defect_displacement(
     return -np.einsum("...ijk,...jk->...i", g_tmp, P)
 
 
-@semantikon_units
+@units
 def get_point_defect_strain(
     C: u(np.ndarray, units="=C"),
     x: u(np.ndarray, units="=x"),
@@ -161,7 +161,7 @@ def get_point_defect_strain(
     return 0.5 * (v + np.einsum("...ij->...ji", v))
 
 
-@semantikon_units
+@units
 def get_point_defect_stress(
     C: u(np.ndarray, units="=C"),
     x: u(np.ndarray, units="=x"),
@@ -195,7 +195,7 @@ def get_point_defect_stress(
     return np.einsum("ijkl,...kl->...ij", C, strain)
 
 
-@semantikon_units
+@units
 def get_point_defect_energy_density(
     C: u(np.ndarray, units="=C"),
     x: u(np.ndarray, units="=x"),

--- a/elaston/inclusion.py
+++ b/elaston/inclusion.py
@@ -4,7 +4,8 @@
 
 import numpy as np
 from elaston.green import get_greens_function
-from elaston.units import units
+from semantikon.typing import u
+from semantikon.converter import units as semantikon_units
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -83,15 +84,15 @@ Vol. 1. Elsevier, 2012.
 """
 
 
-@units(outputs=lambda C, x, P: P.u / C.u / x.u**2)
+@semantikon_units
 def get_point_defect_displacement(
-    C: np.ndarray,
-    x: np.ndarray,
-    P: np.ndarray,
+    C: u(np.ndarray, units="=C"),
+    x: u(np.ndarray, units="=x"),
+    P: u(np.ndarray, units="=P"),
     n_mesh: int = 100,
     optimize: bool = True,
     check_unique: bool = False,
-):
+) -> u(np.ndarray, units="=P/C/x**2"):
     """
     Displacement field around a point defect
 
@@ -121,15 +122,15 @@ def get_point_defect_displacement(
     return -np.einsum("...ijk,...jk->...i", g_tmp, P)
 
 
-@units(outputs=lambda C, x, P: P.u / C.u / x.u**3)
+@semantikon_units
 def get_point_defect_strain(
-    C: np.ndarray,
-    x: np.ndarray,
-    P: np.ndarray,
+    C: u(np.ndarray, units="=C"),
+    x: u(np.ndarray, units="=x"),
+    P: u(np.ndarray, units="=P"),
     n_mesh: int = 100,
     optimize: bool = True,
     check_unique: bool = False,
-):
+) -> u(np.ndarray, units="=P/C/x**3"):
     """
     Strain field around a point defect using the Green's function method
 
@@ -160,14 +161,14 @@ def get_point_defect_strain(
     return 0.5 * (v + np.einsum("...ij->...ji", v))
 
 
-@units(outputs=lambda x, P: P.u / x.u**3)
+@semantikon_units
 def get_point_defect_stress(
-    C: np.ndarray,
-    x: np.ndarray,
-    P: np.ndarray,
+    C: u(np.ndarray, units="=C"),
+    x: u(np.ndarray, units="=x"),
+    P: u(np.ndarray, units="=P"),
     n_mesh: int = 100,
     optimize: bool = True,
-):
+) -> u(np.ndarray, units="=P/C/x**3"):
     """
     Stress field around a point defect using the Green's function method
 
@@ -194,14 +195,14 @@ def get_point_defect_stress(
     return np.einsum("ijkl,...kl->...ij", C, strain)
 
 
-@units(outputs=lambda C, x, P: P.u**2 / C.u / x.u**6)
+@semantikon_units
 def get_point_defect_energy_density(
-    C: np.ndarray,
-    x: np.ndarray,
-    P: np.ndarray,
+    C: u(np.ndarray, units="=C"),
+    x: u(np.ndarray, units="=x"),
+    P: u(np.ndarray, units="=P"),
     n_mesh: int = 100,
     optimize: bool = True,
-):
+) -> u(np.ndarray, units="=P**2/C/x**6"):
     """
     Energy density field around a point defect using the Green's function method
 

--- a/elaston/tools.py
+++ b/elaston/tools.py
@@ -4,7 +4,8 @@
 
 import numpy as np
 import string
-from elaston.units import units
+from semantikon.typing import u
+from semantikon.converter import units
 
 
 __author__ = "Sam Waseda"
@@ -86,8 +87,10 @@ def index_from_voigt(i, j):
         return 6 - i - j
 
 
-@units(outputs=lambda C_in: C_in.u)
-def C_from_voigt(C_in, inverse=False):
+@units
+def C_from_voigt(
+    C_in: u(np.ndarray, units="=C"), inverse=False
+) -> u(np.ndarray, units="=C"):
     """
     Convert elastic tensor in Voigt notation to matrix notation.
 
@@ -111,8 +114,8 @@ def C_from_voigt(C_in, inverse=False):
     return C
 
 
-@units(outputs=lambda C_in: C_in.u)
-def C_to_voigt(C_in):
+@units
+def C_to_voigt(C_in: u(np.ndarray, units="=C")) -> u(np.ndarray, units="=C"):
     """
     Convert elastic tensor in matrix notation to Voigt notation.
 


### PR DESCRIPTION
Since `semantikon` got merged, I started removing elaston units.