### PR TITLE
Fix/bugs

### DIFF
--- a/elaston/dislocation.py
+++ b/elaston/dislocation.py
@@ -263,7 +263,7 @@ def get_dislocation_energy(
     strain = get_dislocation_strain(elastic_tensor, r, burgers_vector=burgers_vector)
     return (
         np.einsum("ijkl,nkl,nij->", elastic_tensor, strain, strain)
-        / np.diff(theta_range)[0]
+        * np.diff(theta_range)[0]
         * r_min**2
         * np.log(r_max / r_min)
     )

--- a/elaston/elastic_constants.py
+++ b/elaston/elastic_constants.py
@@ -308,7 +308,7 @@ def get_elastic_moduli(C: np.ndarray) -> dict[str, float]:
         "youngs_modulus": (C_11 - C_12) * (C_11 + 2 * C_12) / (C_11 + C_12),
         "poissons_ratio": C_12 / (C_11 + C_12),
         "shear_modulus": C_44,
-        "lamé_first_parameter": (C_12 + C_44) / 2,
+        "lamé_first_parameter": C_12,
         "bulk_modulus": (C_11 + 2 * C_12) / 3,
     }
 

--- a/elaston/green.py
+++ b/elaston/green.py
@@ -178,7 +178,7 @@ class Isotropic(Green):
                 )
                 + self.B
                 * np.einsum(
-                    "...,...i,...j->nij",
+                    "...,...i,...j->...ij",
                     np.cos(K * self.min_dist) / K**4
                     - 3 * np.sin(K * self.min_dist) / (K**5 * self.min_dist),
                     k,

--- a/elaston/green.py
+++ b/elaston/green.py
@@ -306,7 +306,7 @@ class Anisotropic(Green):
         )
         self.optimize = optimize
 
-    @cached_property
+    @property
     def z(self) -> np.ndarray:
         """Unit vector in the direction of the azimuthal angle."""
         return np.einsum(
@@ -315,7 +315,7 @@ class Anisotropic(Green):
             [np.cos(self.phi_range), np.sin(self.phi_range)],
         )
 
-    @cached_property
+    @property
     def Ms(self) -> np.ndarray:
         """Inverse of the matrix `Ms`."""
         return np.linalg.inv(
@@ -324,17 +324,17 @@ class Anisotropic(Green):
             )
         )
 
-    @cached_property
+    @property
     def T(self) -> np.ndarray:
         """Normalized `r`."""
         return tools.normalize(self.r)
 
-    @cached_property
+    @property
     def zT(self) -> np.ndarray:
         zT = np.einsum("...p,...w->...pw", self.z, self.T)
         return zT + np.einsum("...ij->...ji", zT)
 
-    @cached_property
+    @property
     def F(self) -> np.ndarray:
         return np.einsum(
             "jpnw,...ij,...nr,...pw->...ir",
@@ -345,7 +345,7 @@ class Anisotropic(Green):
             optimize=self.optimize,
         )
 
-    @cached_property
+    @property
     def MF(self) -> np.ndarray:
         MF = np.einsum("...ij,...nr->...ijnr", self.F, self.Ms)
         return MF + np.einsum("...ijnr->...nrij", MF)

--- a/elaston/tools.py
+++ b/elaston/tools.py
@@ -58,14 +58,17 @@ def get_plane(T: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """
     Get a plane perpendicular to a vector.
 
+    Selects the standard basis vector least aligned with T as a reference to
+    ensure a deterministic, well-conditioned result for any input direction.
+
     Args:
-        T (numpy.ndarray): A vector.
+        T (numpy.ndarray): A unit vector or array of unit vectors (..., 3).
 
     Returns:
-        tuple: A pair of vectors that span the plane.
+        tuple: A pair of vectors that span the plane perpendicular to T.
     """
-    x = normalize(np.random.random(T.shape))
-    x = normalize(x - np.einsum("...i,...i,...j->...j", x, T, T))
+    ref = np.eye(3)[np.argmin(np.abs(T), axis=-1)]
+    x = normalize(ref - np.einsum("...i,...i,...j->...j", ref, T, T))
     y = np.cross(T, x)
     return x, y
 


### PR DESCRIPTION
This pull request introduces several corrections and improvements to the elaston package, focusing on mathematical correctness, code robustness, and performance. The most significant changes include fixing a formula for dislocation energy, correcting the computation of elastic moduli, improving deterministic behavior in plane calculations, and optimizing property usage in the Green's function class.

**Physics and Mathematical Corrections:**

* Fixed the formula in `get_dislocation_energy` in `elaston/dislocation.py` by replacing a division with a multiplication, ensuring the correct integration over the angular range.
* Corrected the calculation of the Lamé first parameter in `get_elastic_moduli` in `elaston/elastic_constants.py`, now using `C_12` instead of `(C_12 + C_44) / 2`.

**Numerical and Algorithmic Improvements:**

* Improved the selection of the reference vector in `get_plane` (`elaston/tools.py`) to ensure deterministic and numerically stable results by choosing the standard basis vector least aligned with the input vector, instead of using a random vector.

**Performance and Code Quality:**

* Replaced `@cached_property` with `@property` for several computed properties (`z`, `Ms`, `T`, `zT`, `F`, `MF`) in `elaston/green.py`, likely to address caching issues or ensure up-to-date results for each call. [[1]](diffhunk://#diff-5e6cdf3d173d6a206035897c748fd6d4810fef60a4584144a1d0a4749f882542L309-R309) [[2]](diffhunk://#diff-5e6cdf3d173d6a206035897c748fd6d4810fef60a4584144a1d0a4749f882542L318-R318) [[3]](diffhunk://#diff-5e6cdf3d173d6a206035897c748fd6d4810fef60a4584144a1d0a4749f882542L327-R337) [[4]](diffhunk://#diff-5e6cdf3d173d6a206035897c748fd6d4810fef60a4584144a1d0a4749f882542L348-R348)
* Fixed the output shape in the `np.einsum` call in `G_fourier` (`elaston/green.py`) by replacing `"nij"` with `"...ij"`, ensuring correct broadcasting and output dimensions.